### PR TITLE
Support multiple instances of a slot in useSlots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cleanweb/oore",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "A library of helpers for writing cleaner React function components with object-oriented patterns.",
 	"engines": {
 		"node": ">=20"

--- a/slots/hook.ts
+++ b/slots/hook.ts
@@ -105,7 +105,17 @@ export const useSlots: IUseSlots = (children, slotComponents, _requiredSlots) =>
 				}
 			}
 
-			if (slotAlias) slotNodes[slotAlias] = child;
+			if (slotAlias) {
+				if (!slotNodes[slotAlias]) {
+					slotNodes[slotAlias] = child;
+				}
+				else if (Array.isArray(slotNodes[slotAlias])) {
+					slotNodes[slotAlias].push(child);
+				}
+				else {
+					slotNodes[slotAlias] = [slotNodes[slotAlias], child];
+				}
+			}
 			else unmatchedChildren.push(child);
 		});
 

--- a/slots/hook.ts
+++ b/slots/hook.ts
@@ -41,7 +41,7 @@ export const getComponentSlotName: IGetSlotName = (TargetComponent, child) => {
 	return undefined;
 };
 
-export const useSlots: IUseSlots = (children, slotComponents, _requiredSlots) => {
+export const useSlots: IUseSlots = (children, slotComponents, requiredSlotAliases) => {
 	type TSlotsRecordArg = typeof slotComponents;
 
 	type TSlotAliasArg = keyof TSlotsRecordArg;
@@ -64,7 +64,7 @@ export const useSlots: IUseSlots = (children, slotComponents, _requiredSlots) =>
 				throwDevError(`A registered slot component did not have a slot name. All components registered as slots must either be a string tag-name or a React component with either "slotName" or "displayName". The affected component was: ${RegisteredSlotComponent}`);
 				return;
 			}
-			return aliasLookup[slotName] = alias;
+			aliasLookup[slotName] = alias;
 		});
 
 		return aliasLookup;
@@ -74,7 +74,7 @@ export const useSlots: IUseSlots = (children, slotComponents, _requiredSlots) =>
 		const slotNodes: TSlotNodesArg = {};
 		const unmatchedChildren: ReactNode[] = [];
 		const invalidChildren: any[] = [];
-		const requiredSlots = [...(_requiredSlots ?? [])];
+		const cachedRequiredSlotAliases = [...(requiredSlotAliases ?? [])];
 
 		React.Children.forEach(children, (child) => {
 			if (!child) {
@@ -101,7 +101,7 @@ export const useSlots: IUseSlots = (children, slotComponents, _requiredSlots) =>
 
 			if (slotAlias && (typeof slotComponents[slotAlias] !== 'string')) {
 				if (slotComponents[slotAlias].isRequiredSlot) {
-					requiredSlots.push(slotAlias);
+					cachedRequiredSlotAliases.push(slotAlias);
 				}
 			}
 
@@ -119,7 +119,7 @@ export const useSlots: IUseSlots = (children, slotComponents, _requiredSlots) =>
 			else unmatchedChildren.push(child);
 		});
 
-		requiredSlots.forEach((slotAlias) => {
+		cachedRequiredSlotAliases.forEach((slotAlias) => {
 			if (!slotNodes[slotAlias]) {
 				throwDevError(`Missing required slot "${String(slotAlias)}".`);
 			}

--- a/slots/types.ts
+++ b/slots/types.ts
@@ -33,7 +33,7 @@ export type SlottedComponent<
 > = TComponentArg & { Slots: TSlotsRecordArg };
 
 export type TSlotNodes<TSlotAliasArg extends TSlotAlias> = {
-	[Key in TSlotAliasArg]?: ReactElement<any>;
+	[Key in TSlotAliasArg]?: ReactElement<any> | Array<ReactElement<any>>;
 };
 
 export type TUseSlotsResult<TSlotAliasArg extends TSlotAlias = TSlotAlias> = Readonly<[

--- a/slots/types.ts
+++ b/slots/types.ts
@@ -46,7 +46,7 @@ export interface IUseSlots {
 	<TSlotAliasArg extends TSlotAlias = TSlotAlias>(
 		children: ReactNode,
 		slotComponents: TSlotsRecord<TSlotAliasArg>,
-		requiredSlots?: TSlotAliasArg[],
+		requiredSlotAliases?: TSlotAliasArg[],
 	): TUseSlotsResult<TSlotAliasArg>;
 }
 


### PR DESCRIPTION
In the useSlots hook, multiple child nodes matching the same slot name were not properly handled. Each matching child would overwrite any previously matched child.

This update allows multiple matching children to be stored in an array. This is essential for use-cases where slots are used to mark specific types of children rather than to represent a specific container/element/child.